### PR TITLE
Add responsiveness for <600px breakpoint devices

### DIFF
--- a/src/components/Apply/FlightInputPanel.tsx
+++ b/src/components/Apply/FlightInputPanel.tsx
@@ -78,6 +78,9 @@ const Container = styled(RowBetween)`
   border-radius: 20px;
   border: 1px solid ${({ theme }) => theme.bg2};
   background-color: ${({ theme }) => theme.bg1};
+  @media (max-width: 600px) {
+    display: block;
+  }
 `
 
 const InputRow = styled.div`

--- a/src/components/Apply/FlightInputPanel.tsx
+++ b/src/components/Apply/FlightInputPanel.tsx
@@ -27,7 +27,8 @@ const CarrierSelect = styled.button<{ selected: boolean }>`
   user-select: none;
   border: none;
   padding: 0 0.5rem;
-
+  flex: 1 1 auto;
+  
   :focus,
   :hover {
     background-color: ${({ theme }) => theme.bg3};

--- a/src/components/Apply/FlightInputPanel.tsx
+++ b/src/components/Apply/FlightInputPanel.tsx
@@ -28,7 +28,6 @@ const CarrierSelect = styled.button<{ selected: boolean }>`
   border: none;
   padding: 0 0.5rem;
   flex: 1 1 auto;
-  
   :focus,
   :hover {
     background-color: ${({ theme }) => theme.bg3};
@@ -105,6 +104,7 @@ const StyledDatePicker = styled.div<{ active?: boolean }>`
   .SingleDatePickerInput {
     .DateInput {
       background: ${({ theme }) => theme.bg2};
+      width: 100%;
     }
     .DateInput_input {
       font-weight: 500;

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -29,6 +29,9 @@ const BodyWrapper = styled.div`
   flex-direction: column;
   width: 100%;
   min-height: 700px;
+  @media (max-width: 600px) {
+    min-height: 770px;
+  }
   padding-top: 100px;
   align-items: center;
   flex: 1;

--- a/src/pages/Apply/index.tsx
+++ b/src/pages/Apply/index.tsx
@@ -35,6 +35,14 @@ const BottomGrouping = styled.div`
 
 const DialogTitle = styled.div`
   ${({ theme }) => theme.flexRowNoWrap}
+  img {
+    width: 400px;
+  }
+  @media (max-width: 600px) {
+    img {
+      width: 300px;
+    }
+  }
 `
 export default function Apply() {
   const { t } = useTranslation()
@@ -131,7 +139,7 @@ export default function Apply() {
           ></ConfirmPurchaseModal>
           <AutoColumn gap={'md'}>
             <DialogTitle>
-              <img width={'400px'} src={isDark ? LogoDark : Logo} alt="logo" />
+              <img src={isDark ? LogoDark : Logo} alt="logo" />
             </DialogTitle>
             <FlightInputPanel
               flight={flight}


### PR DESCRIPTION
1. Display flight input fields by row on mobile devices - media query @600px
2. Stretch airline input field to take all available space
3. Adjust inner width for date input and app height to accommodate date selector
4. Adjust flight delay logo size on mobiles